### PR TITLE
feat: add contact phone and LocalBusiness JSON-LD for local SEO

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -15,6 +15,26 @@ inventory.sort((a, b) => (a.data.order || 1000000) - (b.data.order || 1000000));
 		<title>Emig Supply</title>
 		<link rel="manifest" href="/manifest.json" />
 		<meta name="theme-color" content="#3b82f6" />
+
+		<script type="application/ld+json">
+		{
+			"@context": "https://schema.org",
+			"@type": "LocalBusiness",
+			"name": "Emig Supply",
+			"telephone": "+1-844-721-6515",
+			"url": "https://supply.emig.family",
+			"address": {
+				"@type": "PostalAddress",
+				"addressLocality": "Eaton",
+				"addressRegion": "OH",
+				"addressCountry": "US"
+			},
+			"areaServed": [
+				{"@type": "Place", "name": "Dayton, OH"},
+				{"@type": "Place", "name": "Richmond, IN"}
+			]
+		}
+		</script>
 	</head>
 	<body class="bg-slate-100 text-slate-900 dark:bg-slate-900 dark:text-slate-100 transition-colors min-h-screen">
 		<div class="container mx-auto px-4 py-12">
@@ -22,7 +42,8 @@ inventory.sort((a, b) => (a.data.order || 1000000) - (b.data.order || 1000000));
 				<h1 class="text-5xl font-extrabold mb-6 tracking-tight text-slate-900 dark:text-slate-100">Emig Supply</h1>
 				<p class="text-xl mb-4 max-w-2xl mx-auto text-slate-700 dark:text-slate-300">Your premier source for locally-made and locally-sourced items, delivered right to your door.</p>
 				<p class="text-sm mb-6 text-slate-600 dark:text-slate-300">Located in Eaton, OH — local delivery within 1 hour.</p>
-				<a href="mailto:supply@emig.family" class="inline-block bg-blue-600 text-white hover:bg-blue-700 font-bold py-4 px-8 rounded-full text-lg transition-all duration-300 transform hover:-translate-y-1">Request Item</a>
+					<p class="text-sm mb-4 text-slate-600 dark:text-slate-300">Call us: <a href="tel:+18447216515" class="font-medium text-blue-600 dark:text-blue-400">+1 (844) 721-6515</a></p>
+					<a href="mailto:supply@emig.family" class="inline-block bg-blue-600 text-white hover:bg-blue-700 font-bold py-4 px-8 rounded-full text-lg transition-all duration-300 transform hover:-translate-y-1">Request Item</a>
 			</header>
 
 			<section class="mb-16">


### PR DESCRIPTION
## Summary

- Add contact phone to header above the Request Item button
- Add LocalBusiness JSON-LD with telephone, address, and areaServed for local SEO (Dayton & Richmond)

## Notes

- Phone: +1-844-721-6515
- Site URL: https://supply.emig.family

Resolves #5